### PR TITLE
fix: fix storage allocatable issue

### DIFF
--- a/pkg/cloudprovider/utils.go
+++ b/pkg/cloudprovider/utils.go
@@ -24,7 +24,7 @@ func (c *CloudProvider) instanceToMachine(ctx context.Context, instanceObj *inst
 	if instanceType != nil {
 		labels = lo.Assign(labels, utils.GetAllSingleValuedRequirementLabels(instanceType))
 		machine.Status.Capacity = functional.FilterMap(instanceType.Capacity, func(_ v1.ResourceName, v resource.Quantity) bool { return !resources.IsZero(v) })
-		machine.Status.Allocatable = functional.FilterMap(instanceType.Allocatable(), func(_ v1.ResourceName, v resource.Quantity) bool { return !resources.IsZero(v) })
+		machine.Status.Allocatable = functional.FilterMap(instanceType.Allocatable(), func(rName v1.ResourceName, v resource.Quantity) bool { return !resources.IsZero(v) && rName != v1.ResourceStorage })
 	}
 
 	if instanceObj.CapacityType != nil {

--- a/vendor/github.com/aws/karpenter-core/pkg/controllers/machine/lifecycle/initialization.go
+++ b/vendor/github.com/aws/karpenter-core/pkg/controllers/machine/lifecycle/initialization.go
@@ -129,7 +129,7 @@ func RequestedResourcesRegistered(node *v1.Node, machine *v1alpha5.Machine) (v1.
 		// annotation says the resource should be there, but it's zero'd in both then the device plugin hasn't
 		// registered it yet.
 		// We wait on allocatable since this is the value that is used in scheduling
-		if resources.IsZero(node.Status.Allocatable[resourceName]) {
+		if resourceName != v1.ResourceStorage && resources.IsZero(node.Status.Allocatable[resourceName]) {
 			return resourceName, false
 		}
 	}


### PR DESCRIPTION
Exclude `resource.storage` from the check as the node returns without this info.