### PR TITLE
fix: Fix a few karpenter-core issues

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -80,8 +80,6 @@ func (c *CloudProvider) Create(ctx context.Context, machine *v1alpha5.Machine) (
 }
 
 func (c *CloudProvider) List(ctx context.Context) ([]*v1alpha5.Machine, error) {
-	klog.InfoS("List")
-
 	machines := []*v1alpha5.Machine{}
 	instances, err := c.instanceProvider.List(ctx)
 	if err != nil {

--- a/pkg/providers/instance/armutils.go
+++ b/pkg/providers/instance/armutils.go
@@ -58,8 +58,6 @@ func deleteAgentPool(ctx context.Context, client AgentPoolsAPI, rg, apName, clus
 }
 
 func getAgentPool(ctx context.Context, client AgentPoolsAPI, rg, apName, clusterName string) (*armcontainerservice.AgentPool, error) {
-	klog.InfoS("getAgentPool", "agentpool", apName)
-
 	resp, err := client.Get(ctx, rg, clusterName, apName, nil)
 	if err != nil {
 		return nil, err
@@ -69,8 +67,6 @@ func getAgentPool(ctx context.Context, client AgentPoolsAPI, rg, apName, cluster
 }
 
 func listAgentPools(ctx context.Context, client AgentPoolsAPI, rg, clusterName string) ([]*armcontainerservice.AgentPool, error) {
-	klog.InfoS("listAgentPools")
-
 	var apList []*armcontainerservice.AgentPool
 	pager := client.NewListPager(rg, clusterName, nil)
 	for pager.More() {

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -126,8 +126,6 @@ func (p *Provider) Create(ctx context.Context, machine *v1alpha5.Machine, instan
 
 // getVMSSNodeProviderID generates the provider ID for a virtual machine scale set.
 func (p *Provider) getVMSSNodeProviderID(subscriptionID, scaleSetName string) string {
-	klog.InfoS("Instance.getVMSSNodeProviderID", "subscriptionID", subscriptionID, "scaleSetName", scaleSetName)
-
 	return fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/0", //vm = 0 as ew have the count always 1
 		subscriptionID,
@@ -137,8 +135,6 @@ func (p *Provider) getVMSSNodeProviderID(subscriptionID, scaleSetName string) st
 }
 
 func (p *Provider) Get(ctx context.Context, id string) (*Instance, error) {
-	klog.InfoS("Instance.Get", "id", id)
-
 	apName, err := utils.ParseAgentPoolNameFromID(id)
 	if err != nil {
 		return nil, fmt.Errorf("getting agentpool name, %w", err)
@@ -153,8 +149,6 @@ func (p *Provider) Get(ctx context.Context, id string) (*Instance, error) {
 }
 
 func (p *Provider) List(ctx context.Context) ([]*Instance, error) {
-	klog.InfoS("Instance.List")
-
 	apList, err := listAgentPools(ctx, p.azClient.agentPoolsClient, p.resourceGroup, p.clusterName)
 	if err != nil {
 		logging.FromContext(ctx).Errorf("Listing agentpools failed: %v", err)
@@ -180,8 +174,6 @@ func (p *Provider) Delete(ctx context.Context, id string) error {
 }
 
 func (p *Provider) fromAgentPoolToInstance(ctx context.Context, apObj *armcontainerservice.AgentPool) (*Instance, error) {
-	klog.InfoS("Instance.fromAgentPoolToInstance", "agentpool", apObj.Name)
-
 	subID, err := utils.ParseSubIDFromID(lo.FromPtr(apObj.ID))
 	if err != nil {
 		return nil, err
@@ -212,8 +204,6 @@ func (p *Provider) fromAgentPoolToInstance(ctx context.Context, apObj *armcontai
 }
 
 func (p *Provider) fromAPListToInstances(ctx context.Context, apList []*armcontainerservice.AgentPool) ([]*Instance, error) {
-	klog.InfoS("Instance.fromAPListToInstances")
-
 	if len(apList) == 0 {
 		return nil, fmt.Errorf("no agentpools found")
 	}
@@ -307,7 +297,6 @@ func orderInstanceTypesByPrice(instanceTypes []*corecloudprovider.InstanceType, 
 }
 
 func (p *Provider) getNodeByName(ctx context.Context, apName string) (*v1.Node, error) {
-	klog.InfoS("Instance.getNodeByName", "agentpool", apName)
 	nodeList := &v1.NodeList{}
 	labelSelector := client.MatchingLabels{"agentpool": apName, "kubernetes.azure.com/agentpool": apName}
 

--- a/vendor/github.com/aws/karpenter-core/pkg/controllers/controllers.go
+++ b/vendor/github.com/aws/karpenter-core/pkg/controllers/controllers.go
@@ -24,7 +24,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/controllers/consistency"
 	machinedisruption "github.com/aws/karpenter-core/pkg/controllers/machine/disruption"
-	machinegarbagecollection "github.com/aws/karpenter-core/pkg/controllers/machine/garbagecollection"
 	machinelifecycle "github.com/aws/karpenter-core/pkg/controllers/machine/lifecycle"
 	machinetermination "github.com/aws/karpenter-core/pkg/controllers/machine/termination"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
@@ -64,7 +63,7 @@ func NewControllers(
 		//counter.NewController(kubeClient, cluster),
 		consistency.NewController(clock, kubeClient, recorder, cloudProvider),
 		machinelifecycle.NewController(clock, kubeClient, cloudProvider, recorder),
-		machinegarbagecollection.NewController(clock, kubeClient, cloudProvider),
+		//		machinegarbagecollection.NewController(clock, kubeClient, cloudProvider),
 		machinetermination.NewController(kubeClient, cloudProvider),
 		machinedisruption.NewController(clock, kubeClient, cluster, cloudProvider),
 	}

--- a/vendor/github.com/aws/karpenter-core/pkg/controllers/machine/lifecycle/registration.go
+++ b/vendor/github.com/aws/karpenter-core/pkg/controllers/machine/lifecycle/registration.go
@@ -70,6 +70,10 @@ func (r *Registration) Reconcile(ctx context.Context, machine *v1alpha5.Machine)
 	logging.FromContext(ctx).Debugf("registered machine")
 	machine.StatusConditions().MarkTrue(v1alpha5.MachineRegistered)
 	machine.Status.NodeName = node.Name
+	// gpu-provisioner: update allocatable and capactity from node as well
+	machine.Status.Allocatable = node.Status.Allocatable
+	machine.Status.Capacity = node.Status.Capacity
+
 	metrics.MachinesRegisteredCounter.With(prometheus.Labels{
 		metrics.ProvisionerLabel: machine.Labels[v1alpha5.ProvisionerNameLabelKey],
 	}).Inc()

--- a/vendor/github.com/aws/karpenter-core/pkg/controllers/state/cluster.go
+++ b/vendor/github.com/aws/karpenter-core/pkg/controllers/state/cluster.go
@@ -401,7 +401,7 @@ func (c *Cluster) newStateFromNode(ctx context.Context, node *v1.Node, oldNode *
 	}
 	if err := multierr.Combine(
 		c.populateStartupTaints(ctx, n),
-		c.populateInflight(ctx, n),
+		//		c.populateInflight(ctx, n),   // gpu-provisioner does not need to calculate inflight capacity
 		c.populateResourceRequests(ctx, n),
 		c.populateVolumeLimits(ctx, n),
 	); err != nil {


### PR DESCRIPTION
This change fixes a few karpenter-core issues:

1) Turn off the garbagecolletor controller for now. This controller tries to delete machine cr if node is not shown up after 10 sec when machine is marked launched. The garbagecolletor controller will always throw errors when a new machine CR is created if the node object has not shown up in current implementation. I will have a follow up change to fix the garbagecolletor.

2) After registering the machine, always populate machine status.allocatable and status.capacity with node status. Otherwise, the machine status are initialized with instanceType info which are inconsistent with the actual node status. This leads to errors reported by consistency controller.

3) Remove populateInflight call. It is difficult to controller when the `node.kubernetes.io/instance-type` is added in the node object. Hence this function always report errors before the label is populated. We don't need this functionality in gpu-provisioner. Hence, remove the code to avoid confusing error logs.

4) Remove unnecessary debug logs.  

