### PR TITLE
feat: Update Node heartbeat in Machine CR

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -106,6 +106,9 @@ func (c *CloudProvider) Get(ctx context.Context, providerID string) (*v1alpha5.M
 	if err != nil {
 		return nil, fmt.Errorf("getting instance , %w", err)
 	}
+	if instance == nil {
+		return nil, fmt.Errorf("cannot find a ready instance , %w", err)
+	}
 	instanceTypes, err := c.GetInstanceTypes(ctx, staticprovisioner.Sp)
 	if err != nil {
 		return nil, fmt.Errorf("getting instance types, %w", err)

--- a/vendor/github.com/aws/karpenter-core/pkg/controllers/controllers.go
+++ b/vendor/github.com/aws/karpenter-core/pkg/controllers/controllers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/controllers/consistency"
 	machinedisruption "github.com/aws/karpenter-core/pkg/controllers/machine/disruption"
+	machinegarbagecollection "github.com/aws/karpenter-core/pkg/controllers/machine/garbagecollection"
 	machinelifecycle "github.com/aws/karpenter-core/pkg/controllers/machine/lifecycle"
 	machinetermination "github.com/aws/karpenter-core/pkg/controllers/machine/termination"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
@@ -63,7 +64,7 @@ func NewControllers(
 		//counter.NewController(kubeClient, cluster),
 		consistency.NewController(clock, kubeClient, recorder, cloudProvider),
 		machinelifecycle.NewController(clock, kubeClient, cloudProvider, recorder),
-		//		machinegarbagecollection.NewController(clock, kubeClient, cloudProvider),
+		machinegarbagecollection.NewController(clock, kubeClient, cloudProvider),
 		machinetermination.NewController(kubeClient, cloudProvider),
 		machinedisruption.NewController(clock, kubeClient, cluster, cloudProvider),
 	}


### PR DESCRIPTION
This change attempts to add Node heartbeat info in Machine CR which is currently not supported in Karpenter core.

The changes include:
1) Change the cloudprovide list api call to exclude nodes that are not found (such as waiting for node object to be created when creating a new machine CR) or are in NotReady state, instead of returning errors. 
2) Leveraging the existing karpenter-core garbagecolloection controller which are triggered as two minutes to update machine Ready condition.
3) Update machine CR annotation with latest heartbeat timestamp.
4) If the machine has been in NotReady for more than 6minutes (assume it is larger than the node update time), delete the machine. The time is subject to change later if it is too short.

Manual test log:
```
achineScaleSets/aks-regular-35132246-vmss/virtualMachines/0", "node": "aks-regular-35132246-vmss000000"}
2023-10-03T23:59:33.683Z        DEBUG   controller.machine.garbagecollection    Update heartbeat for 1 machines
2023-10-04T00:01:34.308Z        DEBUG   controller.machine.garbagecollection    Update heartbeat for 1 machines
2023-10-04T00:03:34.806Z        DEBUG   controller.machine.garbagecollection    Update heartbeat for 1 machines
// Stop the vm
2023-10-04T00:05:35.559Z        DEBUG   controller.machine.garbagecollection    Update heartbeat for 0 machines
// Start the vm
2023-10-04T00:07:36.142Z        DEBUG   controller.machine.garbagecollection    Update heartbeat for 1 machines
// Stop the vm again
2023-10-04T00:09:37.009Z        DEBUG   controller.machine.garbagecollection    Update heartbeat for 0 machines
2023-10-04T00:11:37.991Z        DEBUG   controller.machine.garbagecollection    Update heartbeat for 0 machines
2023-10-04T00:13:38.656Z        DEBUG   controller.machine.garbagecollection    Update heartbeat for 0 machines
2023-10-04T00:15:39.470Z        DEBUG   controller.machine.garbagecollection    Update heartbeat for 0 machines
2023-10-04T00:15:39.482Z        DEBUG   controller.machine.garbagecollection    garbage collecting machine with no cloudprovider representation for more than 6 minutes    {"provisioner": "default", "machine": "machine-regular-vms", "provider-id": "azure:///subscriptions/ff05f55d-22b5-44a7-b704-f9a8efd493ed/resourceGroups/mc_fei-test_fei-test-vk-permission_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-regular-35132246-vmss/virtualMachines/0"}
2023-10-04T00:15:39.527Z        INFO    controller.termination  cordoned node   {"node": "aks-regular-35132246-vmss000000"}
2023-10-04T00:15:39.527Z        INFO    controller      Delete  {"machine": {"name":"aks-regular-35132246-vmss000000"}}

```
