### PR TITLE
fix: Use machine name for agentpool name

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -92,7 +92,11 @@ func NewProvider(
 func (p *Provider) Create(ctx context.Context, machine *v1alpha5.Machine, instanceTypes []*corecloudprovider.InstanceType) (*Instance, error) {
 	klog.InfoS("Instance.Create", "machine", klog.KObj(machine))
 
-	apName := strings.ReplaceAll(machine.Spec.MachineTemplateRef.Name, "-", "")
+	apName := strings.ReplaceAll(machine.Name, "-", "")
+	if len(apName) > 11 {
+		//https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/aks-common-issues-faq#what-naming-restrictions-are-enforced-for-aks-resources-and-parameters-
+		return nil, fmt.Errorf("agentpool %q name is too long", apName)
+	}
 
 	if len(instanceTypes) == 0 {
 		return nil, fmt.Errorf("creating agentpool %q failed: %v", apName, "instanceTypes cannot be nil")


### PR DESCRIPTION
This change uses machine name for the agent pool, but the name length is limited to 11 based on AKS limit.
Also fix a bug for counting. AtomicInt should be used.