### PR TITLE
feat: Add node gc

### DIFF
--- a/vendor/github.com/aws/karpenter-core/pkg/controllers/machine/garbagecollection/controller.go
+++ b/vendor/github.com/aws/karpenter-core/pkg/controllers/machine/garbagecollection/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -62,17 +63,56 @@ func (c *Controller) Name() string {
 	return "machine.garbagecollection"
 }
 
-// gpu-provisioner: leverage two perodic check to update machine readiness heartbeat
 func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	merr := c.reconcileMachines(ctx)
+	nerr := c.reconcileNodes(ctx)
+
+	return reconcile.Result{RequeueAfter: time.Minute * 2}, multierr.Combine(merr, nerr)
+}
+
+func (c *Controller) reconcileNodes(ctx context.Context) error {
+	nodeList := &v1.NodeList{}
+	if err := c.kubeClient.List(ctx, nodeList); err != nil {
+		return err
+	}
+
+	deletedGarbageNodes := lo.Filter(lo.ToSlicePtr(nodeList.Items), func(n *v1.Node, _ int) bool {
+		_, ok := n.Labels[v1alpha5.ProvisionerNameLabelKey]
+		if ok && n.Spec.ProviderID != "" {
+			machineList := &v1alpha5.MachineList{}
+			if err := c.kubeClient.List(ctx, machineList, client.MatchingFields{"status.providerID": n.Spec.ProviderID}); err == nil {
+				if len(machineList.Items) == 0 {
+					// The linked machine CR is gone for some reason
+					return true
+				}
+			}
+		}
+		return false
+	})
+
+	errs := make([]error, len(deletedGarbageNodes))
+	workqueue.ParallelizeUntil(ctx, 20, len(deletedGarbageNodes), func(i int) {
+		// We delete nodes to trigger the node finalization and deletion flow
+		if err := c.kubeClient.Delete(ctx, deletedGarbageNodes[i]); client.IgnoreNotFound(err) != nil {
+			errs[i] = err
+			return
+		}
+		logging.FromContext(ctx).Debugf("garbage collecting node %s since the linked machine does not exist", deletedGarbageNodes[i].Name)
+	})
+	return multierr.Combine(errs...)
+}
+
+// gpu-provisioner: leverage the two minutes perodic check to update machine readiness heartbeat
+func (c *Controller) reconcileMachines(ctx context.Context) error {
 	machineList := &v1alpha5.MachineList{}
 	if err := c.kubeClient.List(ctx, machineList); err != nil {
-		return reconcile.Result{}, err
+		return err
 	}
 
 	// The NotReady nodes are excluded from the list
 	cloudProviderMachines, err := c.cloudProvider.List(ctx)
 	if err != nil {
-		return reconcile.Result{}, err
+		return err
 	}
 	cloudProviderMachines = lo.Filter(cloudProviderMachines, func(m *v1alpha5.Machine, _ int) bool {
 		return m.DeletionTimestamp.IsZero()
@@ -81,14 +121,13 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		return m.Status.ProviderID
 	})...)
 
-	// Allows deleting machines that have not launched for more than 10 minutes.
-	deletedNotLaunchedMachines := lo.Filter(lo.ToSlicePtr(machineList.Items), func(m *v1alpha5.Machine, _ int) bool {
-		return !m.StatusConditions().GetCondition(v1alpha5.MachineLaunched).IsTrue() &&
-			!m.DeletionTimestamp.IsZero() &&
-			c.clock.Since(m.StatusConditions().GetCondition(v1alpha5.MachineLaunched).LastTransitionTime.Inner.Time) > time.Minute*10
+	deletedGarbageMachines := lo.Filter(lo.ToSlicePtr(machineList.Items), func(m *v1alpha5.Machine, _ int) bool {
+		// The assumption is that any clean up work should be done in 10 minutes.
+		// The node gc will cover any problems caused by this force deletion.
+		return !m.DeletionTimestamp.IsZero() && metav1.Now().After((*m.DeletionTimestamp).Add(time.Minute*10))
 	})
 
-	rfErrs := c.batchDeleteMachines(ctx, deletedNotLaunchedMachines, true, "to be deleted and has not been launched for more than 10 minutes")
+	rfErrs := c.batchDeleteMachines(ctx, deletedGarbageMachines, true, "to be delete but blocked by finializer for more than 10 minutes")
 
 	// Check all machine heartbeats
 	hbMachines := lo.Filter(lo.ToSlicePtr(machineList.Items), func(m *v1alpha5.Machine, _ int) bool {
@@ -130,16 +169,16 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			return
 		}
 		if !updateCopy.StatusConditions().IsHappy() &&
-			c.clock.Since(updateCopy.StatusConditions().GetCondition("Ready").LastTransitionTime.Inner.Time) > time.Minute*6 {
+			c.clock.Since(updateCopy.StatusConditions().GetCondition("Ready").LastTransitionTime.Inner.Time) > time.Minute*10 {
 			deletedNotReadyMachines = append(deletedNotReadyMachines, updateCopy)
 		}
 	})
 	logging.FromContext(ctx).Debugf(fmt.Sprintf("Update heartbeat for %d out of %d machines", hbUpdated.Load(), len(hbMachines)))
 
-	errs := c.batchDeleteMachines(ctx, deletedNotReadyMachines, false, "being NotReady for more than 6 minutes")
+	errs := c.batchDeleteMachines(ctx, deletedNotReadyMachines, false, "being NotReady for more than 10 minutes")
 	errs = append(errs, hbErrs...)
 	errs = append(errs, rfErrs...)
-	return reconcile.Result{RequeueAfter: time.Minute * 2}, multierr.Combine(errs...)
+	return multierr.Combine(errs...)
 }
 
 func (c *Controller) batchDeleteMachines(ctx context.Context, machines []*v1alpha5.Machine, removeFinalizer bool, msg string) []error {
@@ -150,13 +189,13 @@ func (c *Controller) batchDeleteMachines(ctx context.Context, machines []*v1alph
 			updated := machines[i].DeepCopy()
 			controllerutil.RemoveFinalizer(updated, v1alpha5.TerminationFinalizer)
 			if !equality.Semantic.DeepEqual(stored, updated) {
-				if err := c.kubeClient.Patch(ctx, updated, client.MergeFrom(stored)); err != nil {
-					errs[i] = client.IgnoreNotFound(err)
+				if err := c.kubeClient.Patch(ctx, updated, client.MergeFrom(stored)); client.IgnoreNotFound(err) != nil {
+					errs[i] = err
 					return
 				}
 			}
-		} else if err := c.kubeClient.Delete(ctx, machines[i]); err != nil {
-			errs[i] = client.IgnoreNotFound(err)
+		} else if err := c.kubeClient.Delete(ctx, machines[i]); client.IgnoreNotFound(err) != nil {
+			errs[i] = err
 			return
 		}
 		logging.FromContext(ctx).


### PR DESCRIPTION
This change adds node gc in case node object becomes a dangling object (without linked machine CR) for any reason (e.g., deleting the machine CR by removing finalizer manually when the gpu-provisioner controller stops working).

This change also generalizes the conditions of deleting the machine if the finalization takes too long for any reason. It works with gc to compensate for each other to deal with all kinds of clean up issues.

