### PR TITLE
fix: Remediate node name conflict

### DIFF
--- a/vendor/github.com/aws/karpenter-core/pkg/controllers/controllers.go
+++ b/vendor/github.com/aws/karpenter-core/pkg/controllers/controllers.go
@@ -28,7 +28,6 @@ import (
 	machinelifecycle "github.com/aws/karpenter-core/pkg/controllers/machine/lifecycle"
 	machinetermination "github.com/aws/karpenter-core/pkg/controllers/machine/termination"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
-	"github.com/aws/karpenter-core/pkg/controllers/state/informer"
 	"github.com/aws/karpenter-core/pkg/controllers/termination"
 	"github.com/aws/karpenter-core/pkg/controllers/termination/terminator"
 	"github.com/aws/karpenter-core/pkg/events"
@@ -54,10 +53,10 @@ func NewControllers(
 		//deprovisioning.NewController(clock, kubeClient, provisioner, cloudProvider, recorder, cluster),
 		//provisioning.NewController(kubeClient, provisioner, recorder),
 		//informer.NewDaemonSetController(kubeClient, cluster),
-		informer.NewNodeController(kubeClient, cluster),
+		//informer.NewNodeController(kubeClient, cluster),
 		//informer.NewPodController(kubeClient, cluster),
 		//informer.NewProvisionerController(kubeClient, cluster),
-		informer.NewMachineController(kubeClient, cluster),
+		//informer.NewMachineController(kubeClient, cluster),
 		termination.NewController(kubeClient, cloudProvider, terminator, recorder),
 		//metricspod.NewController(kubeClient),
 		//metricsprovisioner.NewController(kubeClient),


### PR DESCRIPTION
This change deals with a rare but hard to be recovered case for node name conflict.
The details are explained in the node comments.

This change also uses hash to generate agent pool name to reduce the chance of name collision. 

Manual Tests:
```
$ k get machine
NAME          TYPE               ZONE   NODE                                  READY   AGE
regular-vms   Standard_D4ls_v5          aks-wsace728ed2-25221907-vmss000000   True    5m58s
regularvms    Standard_D4ls_v5          aks-wsace728ed2-25221907-vmss000000   True    105s
```
Logs:
```
2023-10-05T23:15:30.644Z        DEBUG   controller.machine.garbagecollection    Update heartbeat for 2 out of 2 machines
2023-10-05T23:15:30.697Z        DEBUG   controller.machine.garbagecollection    delete machine regularvms because it has a node name conflict with machine regular-vms
```
