### PR TITLE
fix: Handle failed machine due to wrong user input

### DIFF
--- a/vendor/github.com/aws/karpenter-core/pkg/controllers/machine/lifecycle/launch.go
+++ b/vendor/github.com/aws/karpenter-core/pkg/controllers/machine/lifecycle/launch.go
@@ -152,8 +152,8 @@ func PopulateMachineDetails(machine, retrieved *v1alpha5.Machine) {
 }
 
 func truncateMessage(msg string) string {
-	if len(msg) < 300 {
+	if len(msg) < 800 {
 		return msg
 	}
-	return msg[:300] + "..."
+	return msg[:800] + "..."
 }


### PR DESCRIPTION
This change handles two common failures due to user input and allow the machines to be deleted right away instead of waiting gc controller to clean them.