### PR TITLE
ci: Add environment to e2e pipeline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       E2E_IMG_TAG: "e2e-gpu"
     runs-on: ubuntu-latest
+    environment: e2e-test
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4


### PR DESCRIPTION
As stated in https://github.com/Azure/login/issues/375, a wild card branch option is not supported for Azure federated identity. Therefore, we are adding an environment to the e2e pipeline to fix dependabot PRs issue.