### PR TITLE
ci: Use 1ES runner for gpu-provisioner workflow jobs that push to ACR

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -1,6 +1,5 @@
 name: Create, Scan and Publish gpu-provisioner image
 on:
-  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -11,12 +10,10 @@ permissions:
   contents: write
   packages: write
 
-
 env:
   REGISTRY: ghcr.io
   GO_VERSION: '1.20'
   IMAGE_NAME: 'gpu-provisioner'
-  IMG_TAG: 'latest'
 
 jobs:
   export-registry:
@@ -30,50 +27,23 @@ jobs:
           # registry must be in lowercase
           echo "registry=$(echo "${{ env.REGISTRY }}/${{ github.repository }}" | tr [:upper:] [:lower:])" >> $GITHUB_OUTPUT
 
-  create-tag:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.title, 'update manifest and helm charts')
-    runs-on: ubuntu-20.04
-    outputs:
-      tag: ${{ steps.get-tag.outputs.tag }}
-    steps:
-      - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION  }}
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: true
-      - id: get-tag
-        name: Get tag
-        run: echo "tag=$(echo ${{ github.event.pull_request.head.ref }} | tr -d release-)" >> $GITHUB_OUTPUT
-      - name: Create tag
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/${{ steps.get-tag.outputs.tag }}',
-              sha: context.sha
-            })
-
   publish-images:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.title, 'update manifest and helm charts')
     needs:
-      - create-tag
       - export-registry
     env:
-      IMG_TAG: ${{ needs.create-tag.outputs.tag }}
       REGISTRY: ${{ needs.export-registry.outputs.registry }}
     runs-on: ubuntu-20.04
     steps:
+      - id: get-tag
+        name: Get tag
+        run: echo "IMG_TAG=$(echo ${{ github.event.pull_request.head.ref }} | tr -d release-)" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
-          ref: ${{ steps.get-tag.outputs.tag }}
+          ref: ${{ env.IMG_TAG }}
+
       - name: Login to ${{ env.REGISTRY }}
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
         with:
@@ -104,12 +74,9 @@ jobs:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Save registry and tag as an artifact for other workflows that run on workflow_run to download them
-        run: |
-          mkdir -p /tmp/artifacts
-          echo ${{ needs.create-tag.outputs.tag }} >> /tmp/artifacts/tag.txt
-          cat /tmp/artifacts/tag.txt
-      - uses: actions/upload-artifact@v4
+      - name: 'Dispatch release tag'
+        uses: peter-evans/repository-dispatch@v3
         with:
-          name: artifacts
-          path: /tmp/artifacts
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: release-tag
+          client-payload: '{"isRelease": true,"registry": "$${{ env.REGISTRY }}","tag": "v${{ env.IMG_TAG }}"}'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,8 +4,12 @@ on:
     workflows: [ "Create, Scan and Publish gpu-provisioner image" ]
     types: [completed]
     branches: [release-**]
+  repository_dispatch:
+    types: [ release-tag ]
+    branches: [ release-** ]
 
 permissions:
+  id-token: write
   contents: write
   packages: write
 
@@ -30,45 +34,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - name: Download tag artifact
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.PROVISIONER_ACCESS_TOKEN_READ }}
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "artifacts"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            let fs = require('fs');
-            fs.writeFileSync(`/tmp/artifacts.zip`, Buffer.from(download.data));
-      - run: |
-          mkdir -p /tmp/artifacts
-          unzip /tmp/artifacts.zip -d /tmp/artifacts
-        shell: bash
-      - run: |
-          echo "Downloaded artifacts:"
-          ls -ablh /tmp/artifacts
-        shell: bash
-      - name: Parse artifacts and assign GA environment variables
-        run: |
-          tag=$(tail -n 1 /tmp/artifacts/tag.txt)
-          echo "IMG_TAG=$tag" >> $GITHUB_ENV
-      - name: Checkout the repository at the given SHA from the artifact
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 0
-          ref: ${{ env.IMG_TAG }}
+          ref: ${{ github.event.client_payload.tag }}
+
       - name: Goreleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,15 +5,16 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:
     branches: [main]
+  repository_dispatch:
+    types: [ release-tag ]
+    branches: [ release-** ]
 
 env:
   GO_VERSION: "1.20"
-  E2E_IMG_TAG: "e2e-gpu"
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -28,15 +29,10 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION  }}
 
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 0
-
       - name: Shorten SHA
+        if: ${{ !github.event.client_payload.isRelease }}
         id: vars
-        run: echo "::set-output name=pr_sha_short::$(git rev-parse --short ${{ github.event.pull_request.head.sha }} )"
+        run: echo "pr_sha_short=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})" >> $GITHUB_OUTPUT
 
       - name: Set e2e Resource and Cluster Name
         run: |
@@ -48,6 +44,28 @@ jobs:
 
           echo "VERSION=${rand}" >> $GITHUB_ENV
           echo "CLUSTER_NAME=gpuprov${rand}" >> $GITHUB_ENV
+          echo "REGISTRY=kaito${rand}.azurecr.io" >> $GITHUB_ENV
+
+      - name: Set Registry
+        if: ${{ github.event.client_payload.isRelease }}
+        run: |
+          echo "REGISTRY=${{ github.event.client_payload.registry }}" >> $GITHUB_ENV
+          echo "VERSION=$(echo ${{ github.event.client_payload.tag }} | tr -d v)" >> $GITHUB_ENV
+
+      - name: Checkout
+        if: ${{ !github.event.client_payload.isRelease }}
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: ${{ github.event.client_payload.isRelease }}
+        with:
+          fetch-depth: 0
+          submodules: true
+          ref: ${{ env.REPO_TAG }}
 
       - uses: azure/login@v1.6.1
         with:
@@ -76,6 +94,7 @@ jobs:
             az identity create --name gpuIdentity --resource-group  ${{ env.CLUSTER_NAME }}
 
       - name: Build gpu-provisioner image
+        if: ${{ !github.event.client_payload.isRelease }}
         shell: bash
         run: |
           make docker-build

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -6,6 +6,14 @@ on:
     types: [ completed ]
     branches: [ release-** ]
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  packages: write
+  contents: write
+  actions: read
+  deployments: read
+  pull-requests: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-to-acr.yaml
+++ b/.github/workflows/publish-to-acr.yaml
@@ -1,45 +1,118 @@
 name: Push image to ACR
 on:
   workflow_dispatch:
-
+    inputs:
+      release_version:
+        description: 'tag to be created for this image (i.e. vxx.xx.xx)'
+        required: true
 
 permissions:
   id-token: write
-  contents: read
-  packages: read
+  contents: write
+  packages: write
 
 env:
   GO_VERSION: '1.20'
+  IMAGE_NAME: 'gpu-provisioner'
 
 jobs:
-  publish:
-    runs-on: ubuntu-20.04
-    environment: publish-mcr
+  check-tag:
+    runs-on:
+      labels: [ self-hosted, "1ES.Pool=${{ matrix.runner }}" ]
+    outputs:
+      tag: ${{ steps.get-tag.outputs.tag }}
     steps:
+      - name: validate version
+        run: |
+          echo "${{ github.event.inputs.release_version }}" | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+$'
+      - id: get-tag
+        name: Get tag
+        run: echo "tag=$(echo ${{ github.event.inputs.release_version }})" >> $GITHUB_OUTPUT
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for Tag
+        run: |
+          TAG="${{ steps.get-tag.outputs.tag }}"
+          if git show-ref --tags --verify --quiet "refs/tags/${TAG}"; then
+            echo "create_tag=$(echo 'false' )" >> $GITHUB_ENV
+          else
+            echo "create_tag=$(echo 'true' )" >> $GITHUB_ENV
+          fi
+      - name: 'Create tag'
+        if:  ${{ env.create_tag == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ steps.get-tag.outputs.tag }}',
+              sha: context.sha
+            })
+
+  publish:
+    runs-on:
+      labels: [ self-hosted, "1ES.Pool=${{ matrix.runner }}" ]
+    environment: publish-mcr
+    needs:
+      - check-tag
+    steps:
+      - id: get-tag
+        name: Get tag
+        run: echo "IMG_TAG=$(echo ${{ needs.check-tag.outputs.tag }} | tr -d v)" >> $GITHUB_ENV
+
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION  }}
-      - name: Set Image Tag
-        run: |
-          echo "IMG_TAG=$(echo "${{ github.ref }}" | tr -d refs/tags/v)" >> $GITHUB_ENV
-          echo "REPO_TAG=$(echo "${{ github.ref }}" | tr -d refs/tags/)" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
-          ref: ${{ env.REPO_TAG }}
-      - name: 'Az CLI login'
-        uses: azure/login@v1.6.1
+          ref: ${{ needs.check-tag.outputs.tag }}
+
+      - name: 'Build Image'
+        run: |
+          OUTPUT_TYPE=type=docker ARCH=arm64 make docker-build
+        env:
+          VERSION: ${{ env.IMG_TAG }}
+          REGISTRY: ${{ secrets.KAITO_MCR_REGISTRY }}/public/aks/kaito
+
+      - name: Scan ${{ secrets.KAITO_MCR_REGISTRY }}/public/aks/kaito/${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }}
+        uses: aquasecurity/trivy-action@master
         with:
-          client-id: ${{ secrets.KAITO_MCR_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.KAITO_MCR_SUBSCRIPTION_ID }}
+          image-ref: ${{ secrets.KAITO_MCR_REGISTRY }}/public/aks/kaito/${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          timeout: '5m0s'
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Dispatch tag to e2e test'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: release-tag
+          client-payload: '{"isRelease": true,"registry": "mcr.microsoft.com/aks/kaito","tag": "${{ needs.check-tag.outputs.tag }}"}'
+
+      - name: Authenticate to ACR
+        run: |
+          az login --identity
+          az acr login -n ${{ secrets.KAITO_MCR_REGISTRY }}
+
       - name: 'Publish to ACR'
         id: Publish
         run: |
-          az acr login -n ${{ secrets.KAITO_MCR_REGISTRY }}
           OUTPUT_TYPE=type=registry make docker-build
         env:
-            VERSION: ${{ env.IMG_TAG }}
-            REGISTRY: ${{ secrets.KAITO_MCR_REGISTRY }}/unlisted/aks/kaito
+          VERSION: ${{ env.IMG_TAG }}
+          REGISTRY: ${{ secrets.KAITO_MCR_REGISTRY }}/public/aks/kaito


### PR DESCRIPTION
- Update push-toacr workflow to use 1ES runner
- Update release workflow to publish MCR image first.