### PR TITLE
fix: Update helm chart to use Release.Namespace

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           echo "IDENTITY_CLIENT_ID=$(az identity show --name gpuIdentity -g "${{ env.CLUSTER_NAME }}" --query 'clientId' -otsv)" >> $GITHUB_ENV
           make az-patch-helm
-          helm install gpu-provisioner ./charts/gpu-provisioner
+          helm install gpu-provisioner ./charts/gpu-provisioner --namespace gpu-provisioner --create-namespace
           kubectl wait --for=condition=available deploy "gpu-provisioner" -n gpu-provisioner --timeout=300s
         env:
           AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}

--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ It implements the cloud provider interfaces to realize the following abstraction
 VERSION=v0.2.0 make docker-build
 make az-identity-perm
 make az-patch-helm
-helm install gpu-provisioner /charts/gpu-provisioner
+helm install gpu-provisioner /charts/gpu-provisioner --namespace gpu-provisioner --create-namespace
 make az-federated-credential
-
 ```
 You should have a running controller in `gpu-provisioner` namespace.
 

--- a/charts/gpu-provisioner/README.md
+++ b/charts/gpu-provisioner/README.md
@@ -9,7 +9,7 @@ A Helm chart for gpu-provisioner
 To install the chart with the release name `gpu-provisioner`:
 
 ```bash
-helm install gpu-provisioner ./charts/gpu-provisioner
+helm install gpu-provisioner ./charts/gpu-provisioner --namespace gpu-provisioner --create-namespace
 ```
 
 ## Values

--- a/charts/gpu-provisioner/templates/clusterrole-core.yaml
+++ b/charts/gpu-provisioner/templates/clusterrole-core.yaml
@@ -15,7 +15,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: gpu-provisioner
-    namespace:  {{ .Values.namespace }}
+    namespace:  {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/gpu-provisioner/templates/configmap-logging.yaml
+++ b/charts/gpu-provisioner/templates/configmap-logging.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gpu-provisioner-config-logging
-  namespace:  {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "gpu-provisioner.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}

--- a/charts/gpu-provisioner/templates/configmap.yaml
+++ b/charts/gpu-provisioner/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gpu-provisioner-global-settings
-  namespace:  {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "gpu-provisioner.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}

--- a/charts/gpu-provisioner/templates/deployment.yaml
+++ b/charts/gpu-provisioner/templates/deployment.yaml
@@ -1,15 +1,8 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.namespace }}
-  labels:
-    {{- include "gpu-provisioner.labels" . | nindent 4 }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "gpu-provisioner.fullname" . }}
-  namespace:  {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     azure.workload.identity/use: "true"
     {{- include "gpu-provisioner.labels" . | nindent 4 }}

--- a/charts/gpu-provisioner/templates/role.yaml
+++ b/charts/gpu-provisioner/templates/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "gpu-provisioner.fullname" . }}
-  namespace:  {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "gpu-provisioner.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}

--- a/charts/gpu-provisioner/templates/rolebinding.yaml
+++ b/charts/gpu-provisioner/templates/rolebinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "gpu-provisioner.fullname" . }}
-  namespace:  {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "gpu-provisioner.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}
@@ -16,7 +16,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: gpu-provisioner
-    namespace:  {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -36,4 +36,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: gpu-provisioner
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/gpu-provisioner/templates/serviceaccount.yaml
+++ b/charts/gpu-provisioner/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: gpu-provisioner
-  namespace:  {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "gpu-provisioner.labels" . | nindent 4 }}
   annotations:

--- a/charts/gpu-provisioner/values.yaml
+++ b/charts/gpu-provisioner/values.yaml
@@ -1,4 +1,3 @@
-namespace: gpu-provisioner
 # -- Overrides the chart's name.
 nameOverride: ""
 # -- Overrides the chart's computed fullname.


### PR DESCRIPTION
Update helm chart to use `Release.Namespace` instead of chart name.