### PR TITLE
chore: Upgrade go version to 1.22

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,7 +9,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.22'
 
 jobs:
   create-release:

--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -39,7 +39,7 @@ jobs:
       id-token: write # This is required for requesting the JWT
     environment: e2e-test
     env:
-      GO_VERSION: "1.21"
+      GO_VERSION: "1.22"
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
     paths-ignore: ["docs/**", "**.md", "**.mdx", "**.png", "**.jpg"]
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -13,7 +13,7 @@ on:
       - main
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.22'
 
 jobs:
   build:

--- a/.github/workflows/publish-mcr-image.yaml
+++ b/.github/workflows/publish-mcr-image.yaml
@@ -12,7 +12,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.22'
   IMAGE_NAME: 'gpu-provisioner'
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.22'
 
 jobs:
   unit-tests:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.21 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/azure/gpu-provisioner
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible


### PR DESCRIPTION
Update go version to 1.22.

Fixes CVE-2024-24788 and CVE-2024-24787