### PR TITLE
chore: remove deprecated goreleaser release actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist --timeout 60m --debug
+          args: release --clean --timeout 60m --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.event.client_payload.tag }}


### PR DESCRIPTION
The gorelaser release following subcommands has been changed:
- `--rm-dist` [deprecated](https://github.com/goreleaser/goreleaser/blob/main/www/docs/deprecations.md#--rm-dist) and replaced by `--clean`
- `--debug` [deprecated](https://github.com/goreleaser/goreleaser/blob/main/www/docs/deprecations.md#--debug) and replaced by `--verbose`