### PR TITLE
fix: add AZURE_SUBSCRIPTION_ID to the script to configure the helm values

### DIFF
--- a/hack/deploy/configure-helm-values.sh
+++ b/hack/deploy/configure-helm-values.sh
@@ -17,15 +17,18 @@ CLUSTER_NAME=$1
 AZURE_RESOURCE_GROUP=$2
 AZURE_GPU_PROVISIONER_USER_ASSIGNED_IDENTITY_NAME=$3
 
-AKS_JSON=$(az aks show --name "$CLUSTER_NAME" --resource-group "$AZURE_RESOURCE_GROUP")
+AKS_JSON=$(az aks show --name "$CLUSTER_NAME" --resource-group "$AZURE_RESOURCE_GROUP" -o json)
 AZURE_LOCATION=$(jq -r ".location" <<< "$AKS_JSON")
 AZURE_RESOURCE_GROUP_MC=$(jq -r ".nodeResourceGroup" <<< "$AKS_JSON")
-AZURE_TENANT_ID=$(az account show |jq -r ".tenantId")
+AZURE_TENANT_ID=$(az account show -o json |jq -r ".tenantId")
+AZURE_SUBSCRIPTION_ID=$(az account show -o json |jq -r ".id")
+
+
 
 
 GPU_PROVISIONER_USER_ASSIGNED_CLIENT_ID=$(az identity show --resource-group "${AZURE_RESOURCE_GROUP}" --name "${AZURE_GPU_PROVISIONER_USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -otsv)
 
-export CLUSTER_NAME AZURE_LOCATION AZURE_RESOURCE_GROUP_MC GPU_PROVISIONER_USER_ASSIGNED_CLIENT_ID AZURE_TENANT_ID
+export CLUSTER_NAME AZURE_LOCATION AZURE_RESOURCE_GROUP_MC GPU_PROVISIONER_USER_ASSIGNED_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
 
 # get gpu-provisioner-values-template.yaml, if not already present (e.g. outside of repo context)
 if [ ! -f gpu-provisioner-values-template.yaml ]; then


### PR DESCRIPTION
The template requires passing AZURE_SUBSCRIPTION_ID

https://github.com/Azure/gpu-provisioner/blob/bbd897d9d2c78efb9926e768326425f691baa103/gpu-provisioner-values-template.yaml#L7

This PR also adds explicit `-o json` output parameters, because not all customers use by default the json output.