### PR TITLE
fix: Export AZURE_RESOURCE_GROUP for substitution

### DIFF
--- a/hack/deploy/configure-helm-values.sh
+++ b/hack/deploy/configure-helm-values.sh
@@ -25,7 +25,7 @@ AZURE_SUBSCRIPTION_ID=$(az account show -o json |jq -r ".id")
 
 GPU_PROVISIONER_USER_ASSIGNED_CLIENT_ID=$(az identity show --resource-group "${AZURE_RESOURCE_GROUP}" --name "${AZURE_GPU_PROVISIONER_USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -otsv)
 
-export CLUSTER_NAME AZURE_LOCATION AZURE_RESOURCE_GROUP_MC GPU_PROVISIONER_USER_ASSIGNED_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
+export CLUSTER_NAME AZURE_LOCATION AZURE_RESOURCE_GROUP AZURE_RESOURCE_GROUP_MC GPU_PROVISIONER_USER_ASSIGNED_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
 
 # get gpu-provisioner-values-template.yaml, if not already present (e.g. outside of repo context)
 if [ ! -f gpu-provisioner-values-template.yaml ]; then


### PR DESCRIPTION
This script is used by KAITO and running the script failed with this error: `Error: variable ${AZURE_RESOURCE_GROUP} not set`.

This variable also needs to be exported for substitution, as it is present in `gpu-provisioner-values-template.yaml`.