### PR TITLE
fix: Yq parsing error

### DIFF
--- a/hack/deploy/configure-helm-values.sh
+++ b/hack/deploy/configure-helm-values.sh
@@ -31,4 +31,4 @@ export CLUSTER_NAME AZURE_LOCATION AZURE_RESOURCE_GROUP AZURE_RESOURCE_GROUP_MC 
 if [ ! -f gpu-provisioner-values-template.yaml ]; then
     curl -sO https://raw.githubusercontent.com/Azure/gpu-provisioner/main/gpu-provisioner-values-template.yaml
 fi
-yq '(.. | select(tag == "!!str")) |= envsubst(nu)' gpu-provisioner-values-template.yaml > gpu-provisioner-values.yaml
+yq '(.. | select(tag == "!!str")) |= envsubst' gpu-provisioner-values-template.yaml > gpu-provisioner-values.yaml


### PR DESCRIPTION
Removing `nu` because it is causing parsing errors, yq will still find and replace all string values in the YAML without any additional parameters.

```
yq '(.. | select(tag == "!!str")) |= envsubst(nu)' gpu-provisioner-values-template.yaml > gpu-provisioner-values.yaml
Error: parsing expression: Lexer error: could not match text starting at 1:43 failing at 1:45.
	unmatched text: "nu)"
```

https://github.com/kaito-project/kaito/actions/runs/11617495492/job/32352844699?pr=641
https://github.com/kaito-project/kaito/actions/runs/11617205418/job/32351888506?pr=641

