### PR TITLE
fix: garbage leaked cloudprovider agentpools

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -98,7 +98,10 @@ func (c *CloudProvider) LivenessProbe(req *http.Request) error {
 
 func (c *CloudProvider) Delete(ctx context.Context, machine *v1alpha5.Machine) error {
 	klog.InfoS("Delete", "machine", klog.KObj(machine))
-	return c.instanceProvider.Delete(ctx, machine.Status.ProviderID)
+	if len(machine.Status.ProviderID) != 0 {
+		return c.instanceProvider.Delete(ctx, machine.Status.ProviderID)
+	}
+	return c.instanceProvider.DeleteByName(ctx, machine.Name)
 }
 
 func (c *CloudProvider) IsMachineDrifted(ctx context.Context, machine *v1alpha5.Machine) (bool, error) {

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -210,7 +210,7 @@ func TestFromAgentPoolToInstance(t *testing.T) {
 
 			p := createTestProvider(agentPoolMocks, mockK8sClient)
 
-			instance, err := p.fromAgentPoolToInstance(context.Background(), &tc.mockAgentPool)
+			instance, err := p.fromRegisteredAgentPoolToInstance(context.Background(), &tc.mockAgentPool)
 
 			if tc.expectedError == nil {
 				assert.NoError(t, err, "Not expected to return error")

--- a/pkg/tests/utils.go
+++ b/pkg/tests/utils.go
@@ -63,7 +63,8 @@ func GetAgentPoolObjWithName(apName string, apId string, vmSize string) armconta
 		Properties: &armcontainerservice.ManagedClusterAgentPoolProfileProperties{
 			VMSize: &vmSize,
 			NodeLabels: map[string]*string{
-				"test": to.Ptr("test"),
+				"test":               to.Ptr("test"),
+				"kaito.sh/workspace": to.Ptr("none"),
 			},
 		},
 	}


### PR DESCRIPTION
- background:
In the following scenario, leaked agentpool problem will happen:
1. create machine crd resource, cloudprovider started to create agentpool resource.
2. delete gpu-provisioner pod, and a new gpu-provisioner pod will be recreated automatically in the cluster.
3. delete machine crd resource.
4. if cloudprovider spent more than 10min to create agentpool, garbage collection controller will remove machine crd, and lead to agentpool leaked.

- solution:
A new agentpool garbage collection(reconcileCloudProviderInstances) is added for removing leaked agentpools that have no assocsiated nodes and machines.