### PR TITLE
ci: Make publish helm chart and create release sequential

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -2,7 +2,7 @@ name: publish_helm_chart
 
 on:
   repository_dispatch:
-    types: [ create-release ]
+    types: [publish-helm-chart ]
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -30,3 +30,15 @@ jobs:
           charts_dir: charts
           target_dir: charts
           linting: off
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [ publish-helm ]
+    environment: e2e-test
+    steps:
+      - name: 'Dispatch release tag to create release'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: create-release
+          client-payload: '{"tag": "${{ github.event.inputs.release_version }}"}'

--- a/.github/workflows/publish-gh-image-and-chart.yml
+++ b/.github/workflows/publish-gh-image-and-chart.yml
@@ -1,4 +1,4 @@
-name: Publish gpu-provisioner image in ghcr and make a release
+name: Publish gpu-provisioner image to ghcr and helm chart
 on:
   workflow_dispatch:
     inputs:
@@ -108,14 +108,14 @@ jobs:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
-  create-release:
+  publish-helm-chart:
     runs-on: ubuntu-latest
     needs: [ build-scan-publish-gh-images ]
     environment: e2e-test  
     steps:
-      - name: 'Dispatch release tag'
+      - name: 'Dispatch release tag to publish helm chart'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: create-release
+          event-type: publish-helm-chart
           client-payload: '{"tag": "${{ github.event.inputs.release_version }}"}'


### PR DESCRIPTION
As part of tighten the security for Kaito pipelines, we enforced approval-based for all workflows that perform writing to the repo. One of the side effects of this was a required approval for the auto triggered 'pages build and deployment' workflow which was missing - and it will get canceled when creating a new release - and caused the helm github page repo to not get updated (https://github.com/kaito-project/kaito/issues/808).

As a solution to that, we will change the Make publish helm chart and create release workflows to run sequentially instead of parallel, so new release won't get created until all (including github pages) are updated successfully.