### PR TITLE
chore: Remove unused env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,6 @@ AZURE_RESOURCE_GROUP ?= <YOUR RG>
 AZURE_ACR_NAME ?= <YOUR ACR>
 AZURE_CLUSTER_NAME ?= <YOUR CLUSTER>
 
-AZURE_RESOURCE_GROUP_MC=MC_$(AZURE_RESOURCE_GROUP)_$(AZURE_CLUSTER_NAME)_$(AZURE_LOCATION)
-
 az-login: ## Login into Azure
 	az login
 	az account set --subscription $(AZURE_SUBSCRIPTION_ID)
@@ -90,7 +88,6 @@ az-patch-helm:  ## Update Azure client env vars and settings in helm values.yml
 	yq -i '(.controller.env[] | select(.name=="LOCATION"))                      .value = "$(AZURE_LOCATION)"'                              ./charts/gpu-provisioner/values.yaml
 	yq -i '(.controller.env[] | select(.name=="ARM_SUBSCRIPTION_ID"))           .value = "$(AZURE_SUBSCRIPTION_ID)"'                       ./charts/gpu-provisioner/values.yaml
 	yq -i '(.controller.env[] | select(.name=="ARM_RESOURCE_GROUP"))            .value = "$(AZURE_RESOURCE_GROUP)"'                        ./charts/gpu-provisioner/values.yaml
-	yq -i '(.controller.env[] | select(.name=="AZURE_NODE_RESOURCE_GROUP"))     .value = "$(AZURE_RESOURCE_GROUP_MC)"'                     ./charts/gpu-provisioner/values.yaml
 	yq -i '(.controller.env[] | select(.name=="AZURE_CLUSTER_NAME"))            .value = "$(AZURE_CLUSTER_NAME)"'                          ./charts/gpu-provisioner/values.yaml
 	yq -i '(.settings.azure.clusterName)                                               = "$(AZURE_CLUSTER_NAME)"'                          ./charts/gpu-provisioner/values.yaml
 	yq -i '(.workloadIdentity.clientId)                                                = "$(IDENTITY_CLIENT_ID)"'                          ./charts/gpu-provisioner/values.yaml

--- a/charts/gpu-provisioner/values.yaml
+++ b/charts/gpu-provisioner/values.yaml
@@ -118,8 +118,6 @@ controller:
       value:
     - name: AZURE_CLUSTER_NAME
       value:
-    - name: AZURE_NODE_RESOURCE_GROUP
-      value:
     - name: ARM_RESOURCE_GROUP
       value:
     - name: LEADER_ELECT # disable leader election for better debugging experience

--- a/gpu-provisioner-values-template.yaml
+++ b/gpu-provisioner-values-template.yaml
@@ -9,8 +9,6 @@ controller:
       value: ${AZURE_LOCATION}
     - name: AZURE_CLUSTER_NAME
       value: ${CLUSTER_NAME}
-    - name: AZURE_NODE_RESOURCE_GROUP
-      value: ${AZURE_RESOURCE_GROUP_MC}
     - name: ARM_RESOURCE_GROUP
       value: ${AZURE_RESOURCE_GROUP}
     - name: LEADER_ELECT # disable leader election for better debugging experience

--- a/hack/deploy/configure-helm-values.sh
+++ b/hack/deploy/configure-helm-values.sh
@@ -19,13 +19,12 @@ AZURE_GPU_PROVISIONER_USER_ASSIGNED_IDENTITY_NAME=$3
 
 AKS_JSON=$(az aks show --name "$CLUSTER_NAME" --resource-group "$AZURE_RESOURCE_GROUP" -o json)
 AZURE_LOCATION=$(jq -r ".location" <<< "$AKS_JSON")
-AZURE_RESOURCE_GROUP_MC=$(jq -r ".nodeResourceGroup" <<< "$AKS_JSON")
 AZURE_TENANT_ID=$(az account show -o json |jq -r ".tenantId")
 AZURE_SUBSCRIPTION_ID=$(az account show -o json |jq -r ".id")
 
 GPU_PROVISIONER_USER_ASSIGNED_CLIENT_ID=$(az identity show --resource-group "${AZURE_RESOURCE_GROUP}" --name "${AZURE_GPU_PROVISIONER_USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -otsv)
 
-export CLUSTER_NAME AZURE_LOCATION AZURE_RESOURCE_GROUP AZURE_RESOURCE_GROUP_MC GPU_PROVISIONER_USER_ASSIGNED_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
+export CLUSTER_NAME AZURE_LOCATION AZURE_RESOURCE_GROUP GPU_PROVISIONER_USER_ASSIGNED_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
 
 # get gpu-provisioner-values-template.yaml, if not already present (e.g. outside of repo context)
 if [ ! -f gpu-provisioner-values-template.yaml ]; then

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -52,9 +52,6 @@ type Config struct {
 
 	//Configs only for AKS
 	ClusterName string `json:"clusterName" yaml:"clusterName"`
-	//Config only for AKS
-	NodeResourceGroup string `json:"nodeResourceGroup" yaml:"nodeResourceGroup"`
-
 	// enableDynamicSKUCache defines whether to enable dynamic instance workflow for instance information check
 	EnableDynamicSKUCache bool `json:"enableDynamicSKUCache,omitempty" yaml:"enableDynamicSKUCache,omitempty"`
 	// EnableDetailedCSEMessage defines whether to emit error messages in the CSE error body info
@@ -80,7 +77,6 @@ func (cfg *Config) BaseVars() {
 	cfg.TenantID = os.Getenv("AZURE_TENANT_ID")
 	cfg.UserAssignedIdentityID = os.Getenv("AZURE_CLIENT_ID")
 	cfg.ClusterName = os.Getenv("AZURE_CLUSTER_NAME")
-	cfg.NodeResourceGroup = os.Getenv("AZURE_NODE_RESOURCE_GROUP")
 	cfg.SubscriptionID = os.Getenv("ARM_SUBSCRIPTION_ID")
 }
 
@@ -124,21 +120,15 @@ func (cfg *Config) TrimSpace() {
 	cfg.SubscriptionID = strings.TrimSpace(cfg.SubscriptionID)
 	cfg.ResourceGroup = strings.TrimSpace(cfg.ResourceGroup)
 	cfg.ClusterName = strings.TrimSpace(cfg.ClusterName)
-	cfg.NodeResourceGroup = strings.TrimSpace(cfg.NodeResourceGroup)
 }
 
 // nolint: gocyclo
 func (cfg *Config) validate() error {
-
 	if cfg.SubscriptionID == "" {
 		return fmt.Errorf("subscription ID not set")
 	}
 	if cfg.TenantID == "" {
 		return fmt.Errorf("tenant ID not set")
-	}
-
-	if cfg.NodeResourceGroup == "" {
-		return fmt.Errorf("node resource group is not set")
 	}
 
 	return nil

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -108,7 +108,7 @@ func TestCreate(t *testing.T) {
 
 			// prepare instance provider
 			mockAzClient := instance.NewAZClientFromAPI(agentPoolMocks)
-			instanceProvider := instance.NewProvider(mockAzClient, mockK8sClient, "testRG", "nodeRG", "testCluster")
+			instanceProvider := instance.NewProvider(mockAzClient, mockK8sClient, "testRG", "testCluster")
 
 			// create cloud provider and call create function
 			cloudProvider := New(instanceProvider, nil)
@@ -205,7 +205,7 @@ func TestList(t *testing.T) {
 
 			// prepare instance provider
 			mockAzClient := instance.NewAZClientFromAPI(agentPoolMocks)
-			instanceProvider := instance.NewProvider(mockAzClient, mockK8sClient, "testRG", "nodeRG", "testCluster")
+			instanceProvider := instance.NewProvider(mockAzClient, mockK8sClient, "testRG", "testCluster")
 
 			// create cloud provider and call list function
 			cloudProvider := New(instanceProvider, nil)
@@ -288,7 +288,7 @@ func TestGet(t *testing.T) {
 
 			// prepare instance provider
 			mockAzClient := instance.NewAZClientFromAPI(agentPoolMocks)
-			instanceProvider := instance.NewProvider(mockAzClient, nil, "testRG", "nodeRG", "testCluster")
+			instanceProvider := instance.NewProvider(mockAzClient, nil, "testRG", "testCluster")
 
 			// create cloud provider and call list function
 			cloudProvider := New(instanceProvider, nil)
@@ -369,7 +369,7 @@ func TestDelete(t *testing.T) {
 
 			// prepare instance provider
 			mockAzClient := instance.NewAZClientFromAPI(agentPoolMocks)
-			instanceProvider := instance.NewProvider(mockAzClient, nil, "testRG", "nodeRG", "testCluster")
+			instanceProvider := instance.NewProvider(mockAzClient, nil, "testRG", "testCluster")
 
 			// create cloud provider and call list function
 			cloudProvider := New(instanceProvider, nil)

--- a/pkg/controllers/instance/garbagecollection/controller_test.go
+++ b/pkg/controllers/instance/garbagecollection/controller_test.go
@@ -262,7 +262,7 @@ func TestReconcile(t *testing.T) {
 
 			// prepare instance provider
 			mockAzClient := instance.NewAZClientFromAPI(agentPoolMocks)
-			instanceProvider := instance.NewProvider(mockAzClient, fakeClient, "testRG", "nodeRG", "testCluster")
+			instanceProvider := instance.NewProvider(mockAzClient, fakeClient, "testRG", "testCluster")
 
 			// create cloud provider
 			cloudProvider := cloudprovider.New(instanceProvider, nil)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -50,7 +50,6 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		azClient,
 		operator.GetClient(),
 		azConfig.ResourceGroup,
-		azConfig.NodeResourceGroup,
 		azConfig.ClusterName,
 	)
 

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -51,26 +51,23 @@ var (
 )
 
 type Provider struct {
-	azClient          *AZClient
-	kubeClient        client.Client
-	resourceGroup     string
-	nodeResourceGroup string
-	clusterName       string
+	azClient      *AZClient
+	kubeClient    client.Client
+	resourceGroup string
+	clusterName   string
 }
 
 func NewProvider(
 	azClient *AZClient,
 	kubeClient client.Client,
 	resourceGroup string,
-	nodeResourceGroup string,
 	clusterName string,
 ) *Provider {
 	return &Provider{
-		azClient:          azClient,
-		kubeClient:        kubeClient,
-		resourceGroup:     resourceGroup,
-		nodeResourceGroup: nodeResourceGroup,
-		clusterName:       clusterName,
+		azClient:      azClient,
+		kubeClient:    kubeClient,
+		resourceGroup: resourceGroup,
+		clusterName:   clusterName,
 	}
 }
 

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -760,7 +760,7 @@ func TestCreateFailure(t *testing.T) {
 
 func createTestProvider(agentPoolsAPIMocks *fake.MockAgentPoolsAPI, mockK8sClient *fake.MockClient) *Provider {
 	mockAzClient := NewAZClientFromAPI(agentPoolsAPIMocks)
-	return NewProvider(mockAzClient, mockK8sClient, "testRG", "nodeRG", "testCluster")
+	return NewProvider(mockAzClient, mockK8sClient, "testRG", "testCluster")
 }
 
 func GetAgentPoolObj(apType armcontainerservice.AgentPoolType, capacityType armcontainerservice.ScaleSetPriority,


### PR DESCRIPTION
The `AZURE_NODE_RESOURCE_GROUP` was set as an environment variable as we forked the repo from Azure Karpenter. For gpu-provisioner, there is no need to pass this env variable via chart. 

This PR is to clean up all the uses of this env variable in the codebase.