### PR TITLE
fix: revert a script change

### DIFF
--- a/gpu-provisioner-values-template.yaml
+++ b/gpu-provisioner-values-template.yaml
@@ -9,6 +9,8 @@ controller:
       value: ${AZURE_LOCATION}
     - name: AZURE_CLUSTER_NAME
       value: ${CLUSTER_NAME}
+    - name: AZURE_NODE_RESOURCE_GROUP
+      value: ${AZURE_RESOURCE_GROUP_MC}    
     - name: ARM_RESOURCE_GROUP
       value: ${AZURE_RESOURCE_GROUP}
     - name: LEADER_ELECT # disable leader election for better debugging experience

--- a/hack/deploy/configure-helm-values.sh
+++ b/hack/deploy/configure-helm-values.sh
@@ -19,12 +19,13 @@ AZURE_GPU_PROVISIONER_USER_ASSIGNED_IDENTITY_NAME=$3
 
 AKS_JSON=$(az aks show --name "$CLUSTER_NAME" --resource-group "$AZURE_RESOURCE_GROUP" -o json)
 AZURE_LOCATION=$(jq -r ".location" <<< "$AKS_JSON")
+AZURE_RESOURCE_GROUP_MC=$(jq -r ".nodeResourceGroup" <<< "$AKS_JSON")
 AZURE_TENANT_ID=$(az account show -o json |jq -r ".tenantId")
 AZURE_SUBSCRIPTION_ID=$(az account show -o json |jq -r ".id")
 
 GPU_PROVISIONER_USER_ASSIGNED_CLIENT_ID=$(az identity show --resource-group "${AZURE_RESOURCE_GROUP}" --name "${AZURE_GPU_PROVISIONER_USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -otsv)
 
-export CLUSTER_NAME AZURE_LOCATION AZURE_RESOURCE_GROUP GPU_PROVISIONER_USER_ASSIGNED_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
+export CLUSTER_NAME AZURE_LOCATION AZURE_RESOURCE_GROUP AZURE_RESOURCE_GROUP_MC GPU_PROVISIONER_USER_ASSIGNED_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
 
 # get gpu-provisioner-values-template.yaml, if not already present (e.g. outside of repo context)
 if [ ! -f gpu-provisioner-values-template.yaml ]; then


### PR DESCRIPTION
This is script is used by another pipeline, and it only works when we release a new version of gpu-provisioner to avoid breaking compatibility with the other pipeline. For now, we need to revert the change. 