### PR TITLE
feat: remove patch terminating status for nodeclaim for adapting new nodeclaim crd changes

### DIFF
--- a/vendor/sigs.k8s.io/karpenter/pkg/controllers/node/termination/controller.go
+++ b/vendor/sigs.k8s.io/karpenter/pkg/controllers/node/termination/controller.go
@@ -89,6 +89,7 @@ func (c *Controller) Reconcile(ctx context.Context, n *corev1.Node) (reconcile.R
 
 //nolint:gocyclo
 func (c *Controller) finalize(ctx context.Context, node *corev1.Node) (reconcile.Result, error) {
+	log.FromContext(ctx).Info("finalize node")
 	if !controllerutil.ContainsFinalizer(node, v1.TerminationFinalizer) {
 		return reconcile.Result{}, nil
 	}
@@ -157,12 +158,12 @@ func (c *Controller) finalize(ctx context.Context, node *corev1.Node) (reconcile
 		// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
 		// can cause races due to the fact that it fully replaces the list on a change
 		// Here, we are updating the status condition list
-		if err = c.kubeClient.Status().Patch(ctx, nodeClaim, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); client.IgnoreNotFound(err) != nil {
-			if errors.IsConflict(err) {
-				return reconcile.Result{Requeue: true}, nil
-			}
-			return reconcile.Result{}, fmt.Errorf("updating nodeclaim, %w", err)
-		}
+		// if err = c.kubeClient.Status().Patch(ctx, nodeClaim, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); client.IgnoreNotFound(err) != nil {
+		// 	if errors.IsConflict(err) {
+		// 		return reconcile.Result{Requeue: true}, nil
+		// 	}
+		// 	return reconcile.Result{}, fmt.Errorf("updating nodeclaim, %w", err)
+		// }
 		// We only increment the drained metric after we have ensured that we have patched the status condition onto the NodeClaim
 		if !stored.StatusConditions().IsTrue(v1.ConditionTypeDrained) && nodeClaim.StatusConditions().IsTrue(v1.ConditionTypeDrained) {
 			// We'll only increment this metric if there is a NodeClaim present for the node, but this prevents us from double

--- a/vendor/sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/vendor/sigs.k8s.io/karpenter/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -179,6 +179,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (re
 
 //nolint:gocyclo
 func (c *Controller) finalize(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
+	log.FromContext(ctx).Info("finalize nodeclaim")
 	if !controllerutil.ContainsFinalizer(nodeClaim, v1.TerminationFinalizer) {
 		return reconcile.Result{}, nil
 	}
@@ -225,15 +226,16 @@ func (c *Controller) finalize(ctx context.Context, nodeClaim *v1.NodeClaim) (rec
 			// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
 			// can cause races due to the fact that it fully replaces the list on a change
 			// Here, we are updating the status condition list
-			if err := c.kubeClient.Status().Patch(ctx, nodeClaim, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); err != nil {
-				if errors.IsNotFound(err) {
-					return reconcile.Result{}, nil
-				}
-				if errors.IsConflict(err) {
-					return reconcile.Result{Requeue: true}, nil
-				}
-				return reconcile.Result{}, err
-			}
+			// if err := c.kubeClient.Status().Patch(ctx, nodeClaim, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); err != nil {
+			// 	if errors.IsNotFound(err) {
+			// 		return reconcile.Result{}, nil
+			// 	}
+			// 	if errors.IsConflict(err) {
+			// 		return reconcile.Result{Requeue: true}, nil
+			// 	}
+			// 	log.FromContext(ctx).Error(err, "failed to patch nodeclaim status")
+			// 	return reconcile.Result{}, err
+			// }
 		}
 		if !cloudprovider.IsNodeClaimNotFoundError(deleteErr) {
 			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil


### PR DESCRIPTION
- Background:
Because in latest NodeClaim CRD, `spec.NodeClassRef.Group` field is not allowed to empty. Then old nodeclaim that created by Kaito(before 0.6.0) can not be deleted by gpu-provisioner. the error as follows:

```
{"level":"INFO","time":"2025-10-17T15:49:18.350Z","logger":"controller","message":"ensure terminated nodeclaim","controller":"node.termination","controllerGroup":"","controllerKind":"Node","Node":{"name":"aks-ws1f323dc0c-28697582-vmss000000"},"namespace":"","name":"aks-ws1f323dc0c-28697582-vmss000000","reconcileID":"d35356ca-bc33-4bf2-b6b4-11ad2c9c66d3","nodeclaim":"ws1f323dc0c","isInstanceTerminated":false,"error":"NodeClaim.karpenter.sh \"ws1f323dc0c\" is invalid: spec.nodeClassRef.group: Invalid value: \"string\": group may not be empty"}
```

- Solution:
The nodeclaim removal is blocked by `patch terminating status for nodeclaim`, so we comment these routine and make sure gpu-provisioner can delete old NodeClaim.