### PR TITLE
release: update manifest and helm charts for v0.3.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= v0.3.6
+VERSION ?= v0.3.7
 # Image URL to use all building/pushing image targets
 REGISTRY ?= ghcr.io/azure/gpu-provisioner
 IMG_NAME ?= gpu-provisioner

--- a/charts/gpu-provisioner/Chart.yaml
+++ b/charts/gpu-provisioner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gpu-provisioner
 description: A Helm chart for gpu-provisioner
 type: application
-version: 0.3.6
-appVersion: 0.3.6
+version: 0.3.7
+appVersion: 0.3.7
 sources:
   - https://github.com/Azure/gpu-provisioner
 maintainers:

--- a/charts/gpu-provisioner/values.yaml
+++ b/charts/gpu-provisioner/values.yaml
@@ -105,7 +105,7 @@ controller:
     # -- Repository path to the controller image.
     repository: mcr.microsoft.com/aks/kaito/gpu-provisioner
     # -- Tag of the controller image.
-    tag: 0.3.6
+    tag: 0.3.7
     # -- SHA256 digest of the controller image.
     digest: ""
   # -- SecurityContext for the controller container.


### PR DESCRIPTION
I have verified all E2E cases in my local env, and all cases passed.

```
------- END CONTROLLER LOGS -------
  < Exit [AfterEach] TOP-LEVEL - /Users/rambohe/go/src/github.com/azure/gpu-provisioner/test/e2e/suites/suite_test.go:43 @ 10/18/25 14:58:32.637 (552ms)
  > Enter [DeferCleanup (Each)] GPU NodeClaim - /Users/rambohe/go/src/github.com/azure/gpu-provisioner/test/e2e/suites/suite_test.go:441 @ 10/18/25 14:58:32.637
  STEP: waiting for created node claims to be == to 0 - /Users/rambohe/go/src/github.com/azure/gpu-provisioner/test/e2e/pkg/environment/common/expectation.go:325 @ 10/18/25 14:58:32.853
  < Exit [DeferCleanup (Each)] GPU NodeClaim - /Users/rambohe/go/src/github.com/azure/gpu-provisioner/test/e2e/suites/suite_test.go:441 @ 10/18/25 14:58:33.123 (486ms)
• [32.461 seconds]
------------------------------

Ran 6 of 6 Specs in 1762.395 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestGPUNodeClaim (1762.40s)
PASS
ok  	command-line-arguments	1762.835s
CLUSTER_NAME=kaitocluster make e2etests  23.29s user 9.84s system 1% cpu 30:02.37 total
```