### PR TITLE
chore: bump Go to 1.26.4 and update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -9,7 +9,7 @@ on:
 
 
 env:
-  GO_VERSION: '1.24.13'
+  GO_VERSION: '1.26.4'
 
 jobs:
   check-files:
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Check spelling with custom config file
-        uses: crate-ci/typos@v1.40.0
+        uses: crate-ci/typos@v1.44.0
         with:
           config: ./.github/typos.toml
       - name: Verify Mod

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,13 +24,13 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5d4e8d1aca955e8d8589aabd499c5cae939e33c7
+        uses: github/codeql-action/init@c793b717bc78562f491db7b0e93a3a178b099162
         with:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@5d4e8d1aca955e8d8589aabd499c5cae939e33c7
+        uses: github/codeql-action/autobuild@c793b717bc78562f491db7b0e93a3a178b099162
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5d4e8d1aca955e8d8589aabd499c5cae939e33c7
+        uses: github/codeql-action/analyze@c793b717bc78562f491db7b0e93a3a178b099162
   

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,14 +9,14 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.24.13'
+  GO_VERSION: '1.26.4'
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
         with:
           egress-policy: audit
 
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.event.client_payload.tag }}
 
       - name: Goreleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean --timeout 60m --verbose

--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -39,11 +39,11 @@ jobs:
       id-token: write # This is required for requesting the JWT
     environment: e2e-test
     env:
-      GO_VERSION: "1.24.13"
+      GO_VERSION: "1.26.4"
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
     paths-ignore: ["docs/**", "**.md", "**.mdx", "**.png", "**.jpg"]
 
 env:
-  GO_VERSION: "1.24.13"
+  GO_VERSION: "1.26.4"
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -13,7 +13,7 @@ on:
       - main
 
 env:
-  GO_VERSION: '1.24.13'
+  GO_VERSION: '1.26.4'
 
 jobs:
   build:
@@ -22,7 +22,7 @@ jobs:
       contents: read
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/publish-gh-image-and-chart.yml
+++ b/.github/workflows/publish-gh-image-and-chart.yml
@@ -12,7 +12,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.24.13'
+  GO_VERSION: '1.26.4'
   IMAGE_NAME: 'gpu-provisioner'
   REGISTRY: ghcr.io
 
@@ -81,7 +81,7 @@ jobs:
           ref: ${{ needs.check-tag.outputs.tag }}
 
       - name: Login to ${{ steps.get-registry.outputs.registry_repository }}
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/publish-mcr-image.yaml
+++ b/.github/workflows/publish-mcr-image.yaml
@@ -12,7 +12,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.24.13'
+  GO_VERSION: '1.26.4'
   IMAGE_NAME: 'gpu-provisioner'
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,14 +19,14 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.24.13'
+  GO_VERSION: '1.26.4'
 
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
         with:
           egress-policy: audit
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24 as builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4 as builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG KARPENTERVER

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/azure/gpu-provisioner
 
-go 1.24.13
+go 1.26.4
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible


### PR DESCRIPTION
Bump the Go toolchain to 1.26.4 to pick up Go stdlib security fixes (resolves stdlib CVEs reported in ICM 816788806):
- go.mod: go directive 1.24.13 -> 1.26.4
- Dockerfile: builder golang:1.24 -> golang:1.26.4
- CI workflows: GO_VERSION 1.24.13 -> 1.26.4

Merge open dependabot GitHub Actions bumps (PRs #296-#300):
- docker/login-action -> 3.7.0
- step-security/harden-runner -> v2.15.0
- github/codeql-action -> c793b71
- goreleaser/goreleaser-action -> v7
- crate-ci/typos -> v1.44.0